### PR TITLE
Enable usage with shiny modules

### DIFF
--- a/R/shiny-server.R
+++ b/R/shiny-server.R
@@ -45,6 +45,9 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 
 	assert_starts_with_digits(heatmap_id)
 
+  
+  non_prefix_heatmap_id = remove_module_prefix(heatmap_id, session)
+  
 	if(is.null(shiny_env$heatmap[[heatmap_id]])) {
 		stop_wrap(qq("Cannot find heatmap '@{heatmap_id}'. Make sure 'ui' is generated in the same session as 'server'. If 'ui' is generated in a package, please generate it dynamically by wrapping into a function, while not do it statically."))
 	}
@@ -55,6 +58,7 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 	if(shiny_env$heatmap[[heatmap_id]]$action == "dblclick") {
 		if(!is.null(dblclick_action)) click_action = dblclick_action
 	}
+  
 	do_default_click_action = shiny_env$heatmap[[heatmap_id]]$default_output_ui; if(is.null(do_default_click_action)) do_default_click_action = FALSE
 	do_default_brush_action = shiny_env$heatmap[[heatmap_id]]$default_output_ui; if(is.null(do_default_brush_action)) do_default_brush_action = FALSE
 
@@ -267,9 +271,9 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 	###############################################################
 	##                 The default actions
 	###############################################################
-	shiny_env$obs[[heatmap_id]][[qq("@{heatmap_id}_initialize")]] = observeEvent(input[[qq("@{heatmap_id}_reset_ui_done")]], {
+	shiny_env$obs[[heatmap_id]][[qq("@{heatmap_id}_initialize")]] = observeEvent(input[[qq("@{non_prefix_heatmap_id}_reset_ui_done")]], {
 
-		output[[qq("@{heatmap_id}_heatmap")]] = renderPlot({
+		output[[qq("@{non_prefix_heatmap_id}_heatmap")]] = renderPlot({
 
 			dvl = dev.list()
 			# if(!grepl("off_screen", names(dvl)[length(dvl)])) {
@@ -286,7 +290,7 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 			ht_pos(ht_pos)
 
 			if(do_default_click_action || do_default_brush_action) {
-				output[[qq("@{heatmap_id}_info")]] = renderUI({
+				output[[qq("@{non_prefix_heatmap_id}_info")]] = renderUI({
 					HTML("<p>No position is selected.</p>")
 				})
 			}
@@ -297,8 +301,8 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 			if(is.null(lt)) {
 				session$sendCustomMessage(qq("@{heatmap_id}_empty_search"), "")
 			} else {
-				updateRadioButtons(session, qq("@{heatmap_id}_search_where"), label = "Which dimension to search?", choices = lt[[1]], selected = lt[[1]][[1]], inline = TRUE)
-				updateCheckboxGroupInput(session, qq("@{heatmap_id}_search_heatmaps"), label = "Which heatmaps to search?", choiceNames = lt[[2]], choiceValues = lt[[2]], selected = lt[[2]])
+				updateRadioButtons(session, qq("@{non_prefix_heatmap_id}_search_where"), label = "Which dimension to search?", choices = lt[[1]], selected = lt[[1]][[1]], inline = TRUE)
+				updateCheckboxGroupInput(session, qq("@{non_prefix_heatmap_id}_search_heatmaps"), label = "Which heatmaps to search?", choiceNames = lt[[2]], choiceValues = lt[[2]], selected = lt[[2]])
 			}
 			session$sendCustomMessage(qq("@{heatmap_id}_initialized"), "")
 
@@ -353,7 +357,7 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 		    heatmap_initialized(TRUE)
 		}, res = res)
 
-		output[[qq("@{heatmap_id}_sub_heatmap")]] = renderPlot({
+		output[[qq("@{non_prefix_heatmap_id}_sub_heatmap")]] = renderPlot({
 			grid.newpage()
 			grid.text("No area on the heatmap is selected.", 0.5, 0.5, gp = gpar(fontsize = 14))
 
@@ -361,7 +365,7 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 		}, res = res)
 
 		if(do_default_click_action || do_default_brush_action) {
-			output[[qq("@{heatmap_id}_info")]] = renderUI({
+			output[[qq("@{non_prefix_heatmap_id}_info")]] = renderUI({
 				HTML("<p>No position is selected.</p>")
 			})
 		}
@@ -370,14 +374,14 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 	###############################################################
 	##                 resizing
 	###############################################################
-	shiny_env$obs[[heatmap_id]][[qq("@{heatmap_id}_heatmap_do_resize")]] = observeEvent(input[[qq("@{heatmap_id}_heatmap_do_resize")]], {
+	shiny_env$obs[[heatmap_id]][[qq("@{heatmap_id}_heatmap_do_resize")]] = observeEvent(input[[qq("@{non_prefix_heatmap_id}_heatmap_do_resize")]] |> debounce(700), {
 
 		req(heatmap_initialized())
 
-		width = input[[qq("@{heatmap_id}_heatmap_resize_width")]]
-	    height = input[[qq("@{heatmap_id}_heatmap_resize_height")]]
+		width = input[[qq("@{non_prefix_heatmap_id}_heatmap_resize_width")]]
+	    height = input[[qq("@{non_prefix_heatmap_id}_heatmap_resize_height")]]
 
-		output[[qq("@{heatmap_id}_heatmap")]] = renderPlot({
+		output[[qq("@{non_prefix_heatmap_id}_heatmap")]] = renderPlot({
 
 			showNotification("Making the original heatmap.", duration = 2, type = "message")
 
@@ -395,7 +399,7 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 	###############################################################
 	##                 The original heatmap
 	###############################################################
-	output[[qq("@{heatmap_id}_heatmap_download_button")]] = downloadHandler(
+	output[[qq("@{non_prefix_heatmap_id}_heatmap_download_button")]] = downloadHandler(
 
 		filename = function() {
 			format = as.numeric(input[[qq("@{heatmap_id}_heatmap_download_format")]])
@@ -404,7 +408,7 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 		},
 		content = function(file) {
 			
-			format = as.numeric(input[[qq("@{heatmap_id}_heatmap_download_format")]])
+			format = as.numeric(input[[qq("@{non_prefix_heatmap_id}_heatmap_download_format")]])
 			fm = c("png", "pdf", "svg")[format]
 			dev = list(png, pdf, svglite::svglite)[[format]]
 
@@ -412,8 +416,8 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 			message(qq("[@{Sys.time()}] Download heatmap in @{fm}."))
 
 			temp = tempfile()
-			width = input[[qq("@{heatmap_id}_heatmap_download_image_width")]]
-			height = input[[qq("@{heatmap_id}_heatmap_download_image_height")]]
+			width = input[[qq("@{non_prefix_heatmap_id}_heatmap_download_image_width")]]
+			height = input[[qq("@{non_prefix_heatmap_id}_heatmap_download_image_height")]]
 			
 			if(fm == "png") {
 				dev(temp, width = width*2, height = height*2, res = 72*2)
@@ -434,14 +438,14 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 		}
 	)
 	
-	shiny_env$obs[[heatmap_id]][[qq("@{heatmap_id}_heatmap_resize_button")]] = observeEvent(input[[qq("@{heatmap_id}_heatmap_resize_button")]], {
+	shiny_env$obs[[heatmap_id]][[qq("@{heatmap_id}_heatmap_resize_button")]] = observeEvent(input[[qq("@{non_prefix_heatmap_id}_heatmap_resize_button")]], {
 
 		req(heatmap_initialized())
 
-		width = input[[qq("@{heatmap_id}_heatmap_input_width")]]
-	    height = input[[qq("@{heatmap_id}_heatmap_input_height")]]
+		width = input[[qq("@{non_prefix_heatmap_id}_heatmap_input_width")]]
+	    height = input[[qq("@{non_prefix_heatmap_id}_heatmap_input_height")]]
 
-		output[[qq("@{heatmap_id}_heatmap")]] = renderPlot({
+		output[[qq("@{non_prefix_heatmap_id}_heatmap")]] = renderPlot({
 			
 	    	draw( ht_list() )
 
@@ -461,16 +465,16 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 	##      sub-heatmap by selecting or searching
 	###############################################################
 	if(has_brush_response) {
-		shiny_env$obs[[heatmap_id]][[qq("@{heatmap_id}_heatmap_brush")]] = observeEvent(input[[qq("@{heatmap_id}_heatmap_brush")]], {
+		shiny_env$obs[[heatmap_id]][[qq("@{heatmap_id}_heatmap_brush")]] = observeEvent(input[[qq("@{non_prefix_heatmap_id}_heatmap_brush")]], {
 
 			req(heatmap_initialized())
 
-			updateCheckboxInput(session, qq("@{heatmap_id}_remove_empty_checkbox"), value = FALSE)
-			if(is.null(input[[qq("@{heatmap_id}_heatmap_brush")]])) {
+			updateCheckboxInput(session, qq("@{non_prefix_heatmap_id}_remove_empty_checkbox"), value = FALSE)
+			if(is.null(input[[qq("@{non_prefix_heatmap_id}_heatmap_brush")]])) {
 				selected( NULL )
 				selected_copy( selected() )
 			} else {
-				lt = get_pos_from_brush(input[[qq("@{heatmap_id}_heatmap_brush")]], res/72)
+				lt = get_pos_from_brush(input[[qq("@{non_prefix_heatmap_id}_heatmap_brush")]], res/72)
 			  	pos1 = lt[[1]]
 			  	pos2 = lt[[2]]
 			    
@@ -480,9 +484,9 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 			    dev.off2()
 			}
 
-			updateTextInput(session, qq("@{heatmap_id}_keyword"), value = "")
+			updateTextInput(session, qq("@{non_prefix_heatmap_id}_keyword"), value = "")
 
-			output[[qq("@{heatmap_id}_sub_heatmap")]] = renderPlot({
+			output[[qq("@{non_prefix_heatmap_id}_sub_heatmap")]] = renderPlot({
 				
 	    		if(is.null( selected() )) {
 	    			grid.newpage()
@@ -507,18 +511,18 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 			session$sendCustomMessage(qq("@{heatmap_id}_sub_initialized"), "on")
 		})
 
-		shiny_env$obs[[heatmap_id]][[qq("@{heatmap_id}_post_remove_submit")]] = observeEvent(input[[qq("@{heatmap_id}_post_remove_submit")]], {
+		shiny_env$obs[[heatmap_id]][[qq("@{heatmap_id}_post_remove_submit")]] = observeEvent(input[[qq("@{non_prefix_heatmap_id}_post_remove_submit")]], {
 
 			req(heatmap_initialized())
-			req(input[[qq("@{heatmap_id}_post_remove")]])
+			req(input[[qq("@{non_prefix_heatmap_id}_post_remove")]])
 
-			where = input[[qq("@{heatmap_id}_post_remove_dimension")]]
-			new_selected = adjust_df(selected(), n_remove = input[[qq("@{heatmap_id}_post_remove")]], 
+			where = input[[qq("@{non_prefix_heatmap_id}_post_remove_dimension")]]
+			new_selected = adjust_df(selected(), n_remove = input[[qq("@{non_prefix_heatmap_id}_post_remove")]], 
 				where = where, ht_direction = ht_list()@direction)
 
 			selected(new_selected)
 
-			output[[qq("@{heatmap_id}_sub_heatmap")]] = renderPlot({
+			output[[qq("@{non_prefix_heatmap_id}_sub_heatmap")]] = renderPlot({
 				
 	    		if(nrow( selected() ) == 0) {
 	    			grid.newpage()
@@ -546,18 +550,18 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 			session$sendCustomMessage(qq("@{heatmap_id}_sub_initialized"), "on")
 		})
 
-		shiny_env$obs[[heatmap_id]][[qq("@{heatmap_id}_remove_empty_checkbox")]] = observeEvent(input[[qq("@{heatmap_id}_remove_empty_checkbox")]], {
+		shiny_env$obs[[heatmap_id]][[qq("@{heatmap_id}_remove_empty_checkbox")]] = observeEvent(input[[qq("@{non_prefix_heatmap_id}_remove_empty_checkbox")]], {
 			
 			req(heatmap_initialized())
 
-			if(input[[qq("@{heatmap_id}_remove_empty_checkbox")]]) {
+			if(input[[qq("@{non_prefix_heatmap_id}_remove_empty_checkbox")]]) {
 				new_selected = adjust_df_remove_empty(selected(), ht_list())
 				selected(new_selected)
 			} else {
 				selected( selected_copy() )
 			}
 			
-			output[[qq("@{heatmap_id}_sub_heatmap")]] = renderPlot({
+			output[[qq("@{non_prefix_heatmap_id}_sub_heatmap")]] = renderPlot({
 				
 	    		if(nrow( selected() ) == 0) {
 	    			grid.newpage()
@@ -585,13 +589,13 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 			session$sendCustomMessage(qq("@{heatmap_id}_sub_initialized"), "on")
 		}, ignoreInit = TRUE)
 
-		shiny_env$obs[[heatmap_id]][[qq("@{heatmap_id}_post_remove_reset")]] = observeEvent(input[[qq("@{heatmap_id}_post_remove_reset")]], {
+		shiny_env$obs[[heatmap_id]][[qq("@{heatmap_id}_post_remove_reset")]] = observeEvent(input[[qq("@{non_prefix_heatmap_id}_post_remove_reset")]], {
 
 			req(heatmap_initialized())
 
 			selected( selected_copy() )
 
-			output[[qq("@{heatmap_id}_sub_heatmap")]] = renderPlot({
+			output[[qq("@{non_prefix_heatmap_id}_sub_heatmap")]] = renderPlot({
 				
 	    		if(is.null( selected() )) {
 	    			grid.newpage()
@@ -613,7 +617,7 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 				}
 			}
 
-			updateCheckboxInput(session, qq("@{heatmap_id}_remove_empty_checkbox"), value = FALSE)
+			updateCheckboxInput(session, qq("@{non_prefix_heatmap_id}_remove_empty_checkbox"), value = FALSE)
 
 			showNotification(qq("reset sub-heatmap."), duration = 2, type = "message")
 	    	message(qq("[@{Sys.time()}] reset sub-heatmap."))
@@ -622,14 +626,14 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 		})
 
 
-		shiny_env$obs[[heatmap_id]][[qq("@{heatmap_id}_search_action")]] = observeEvent(input[[qq("@{heatmap_id}_search_action")]], {
+		shiny_env$obs[[heatmap_id]][[qq("@{heatmap_id}_search_action")]] = observeEvent(input[[qq("@{non_prefix_heatmap_id}_search_action")]], {
 
 			req(heatmap_initialized())
 
-			updateCheckboxInput(session, qq("@{heatmap_id}_remove_empty_checkbox"), value = FALSE)
+			updateCheckboxInput(session, qq("@{non_prefix_heatmap_id}_remove_empty_checkbox"), value = FALSE)
 			
-			if(input[[qq("@{heatmap_id}_keyword")]] == "") {
-				output[[qq("@{heatmap_id}_sub_heatmap")]] = renderPlot({
+			if(input[[qq("@{non_prefix_heatmap_id}_keyword")]] == "") {
+				output[[qq("@{non_prefix_heatmap_id}_sub_heatmap")]] = renderPlot({
 					grid.newpage()
 					grid.text("Query keyword is empty.", 0.5, 0.5, gp = gpar(fontsize = 14, col = "red"))
 				}, res = res)
@@ -651,15 +655,15 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 				return(invisible(NULL))
 			}
 
-			keywords2 = keywords = input[[qq("@{heatmap_id}_keyword")]]
+			keywords2 = keywords = input[[qq("@{non_prefix_heatmap_id}_keyword")]]
 
-			where = input[[qq("@{heatmap_id}_search_where")]]
-			is_regexpr = input[[qq("@{heatmap_id}_search_regexpr")]]
-			sht = input[[qq("@{heatmap_id}_search_heatmaps")]]
-			extend = input[[qq("@{heatmap_id}_search_extend")]]
+			where = input[[qq("@{non_prefix_heatmap_id}_search_where")]]
+			is_regexpr = input[[qq("@{non_prefix_heatmap_id}_search_regexpr")]]
+			sht = input[[qq("@{non_prefix_heatmap_id}_search_heatmaps")]]
+			extend = input[[qq("@{non_prefix_heatmap_id}_search_extend")]]
 
 			if(length(sht) == 0) {
-				output[[qq("@{heatmap_id}_sub_heatmap")]] = renderPlot({
+				output[[qq("@{non_prefix_heatmap_id}_sub_heatmap")]] = renderPlot({
 					grid.newpage()
 					grid.text("No heatmap is selected for searching.", 0.5, 0.5, gp = gpar(fontsize = 14, col = "red"))
 				}, res = res)
@@ -701,7 +705,7 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 			}
 			selected_copy( selected() )
 
-			output[[qq("@{heatmap_id}_sub_heatmap")]] = renderPlot({
+			output[[qq("@{non_prefix_heatmap_id}_sub_heatmap")]] = renderPlot({
 				
 	    		if(is.null(selected())) {
 	    			grid.newpage()
@@ -737,16 +741,16 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 
 		})
 
-		output[[qq("@{heatmap_id}_sub_heatmap_download_button")]] = downloadHandler(
+		output[[qq("@{non_prefix_heatmap_id}_sub_heatmap_download_button")]] = downloadHandler(
 
 			filename = function() {
-				format = as.numeric(input[[qq("@{heatmap_id}_sub_heatmap_download_format")]])
+				format = as.numeric(input[[qq("@{non_prefix_heatmap_id}_sub_heatmap_download_format")]])
 				fm = c("png", "pdf", "svg")[format]
 				qq("@{heatmap_id}_sub_heatmap.@{fm}")
 			},
 			content = function(file) {
 				
-				format = as.numeric(input[[qq("@{heatmap_id}_sub_heatmap_download_format")]])
+				format = as.numeric(input[[qq("@{non_prefix_heatmap_id}_sub_heatmap_download_format")]])
 				fm = c("png", "pdf", "svg")[format]
 				dev = list(png, pdf, svglite::svglite)[[format]]
 
@@ -754,8 +758,8 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 				message(qq("[@{Sys.time()}] Download sub-heatmap in @{fm}."))
 
 				temp = tempfile()
-				width = input[[qq("@{heatmap_id}_sub_heatmap_download_image_width")]]
-				height = input[[qq("@{heatmap_id}_sub_heatmap_download_image_height")]]
+				width = input[[qq("@{non_prefix_heatmap_id}_sub_heatmap_download_image_width")]]
+				height = input[[qq("@{non_prefix_heatmap_id}_sub_heatmap_download_image_height")]]
 				
 				if(fm == "png") {
 					dev(temp, width = width*2, height = height*2, res = 72*2)
@@ -776,11 +780,11 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 			}
 		)
 		
-		shiny_env$obs[[heatmap_id]][[qq("@{heatmap_id}_sub_heatmap_input_size_button")]] = observeEvent(input[[qq("@{heatmap_id}_sub_heatmap_input_size_button")]], {
+		shiny_env$obs[[heatmap_id]][[qq("@{heatmap_id}_sub_heatmap_input_size_button")]] = observeEvent(input[[qq("@{non_prefix_heatmap_id}_sub_heatmap_input_size_button")]], {
 			
 			req(heatmap_initialized())
 
-			output[[qq("@{heatmap_id}_sub_heatmap")]] = renderPlot({
+			output[[qq("@{non_prefix_heatmap_id}_sub_heatmap")]] = renderPlot({
 				if(is.null(selected())) {
 	    			grid.newpage()
 					grid.text("No area on the heatmap is selected.", 0.5, 0.5, gp = gpar(fontsize = 14))
@@ -790,7 +794,7 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 			}, res = res)
 		})
 
-		shiny_env$obs[[heatmap_id]][[qq("@{heatmap_id}_open_table")]] = observeEvent(input[[qq("@{heatmap_id}_open_table")]], {
+		shiny_env$obs[[heatmap_id]][[qq("@{heatmap_id}_open_table")]] = observeEvent(input[[qq("@{non_prefix_heatmap_id}_open_table")]], {
 
 			req(heatmap_initialized())
 
@@ -828,25 +832,25 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 
 		})
 
-		shiny_env$obs[[heatmap_id]][[qq("@{heatmap_id}_selected_table_create")]] = observeEvent(input[[qq("@{heatmap_id}_selected_table_create")]], {
+		shiny_env$obs[[heatmap_id]][[qq("@{heatmap_id}_selected_table_create")]] = observeEvent(input[[qq("@{non_prefix_heatmap_id}_selected_table_create")]], {
 			
 			req(heatmap_initialized())
 
-			output[[qq("@{heatmap_id}_selected_table")]] = renderUI({
+			output[[qq("@{non_prefix_heatmap_id}_selected_table")]] = renderUI({
 				HTML(format_html_table(heatmap_id, selected = selected(), ht_list = ht_list()))
 			})
 		})
 
-		shiny_env$obs[[heatmap_id]][[qq("@{heatmap_id}_digits")]] = observeEvent(input[[qq("@{heatmap_id}_digits")]], {
+		shiny_env$obs[[heatmap_id]][[qq("@{heatmap_id}_digits")]] = observeEvent(input[[qq("@{non_prefix_heatmap_id}_digits")]], {
 
 			req(heatmap_initialized())
 
-			output[[qq("@{heatmap_id}_selected_table")]] = renderUI({
-				HTML(format_html_table(heatmap_id, input[[qq("@{heatmap_id}_digits")]], selected = selected(), ht_list = ht_list()))
+			output[[qq("@{non_prefix_heatmap_id}_selected_table")]] = renderUI({
+				HTML(format_html_table(heatmap_id, digits = input[[qq("@{non_prefix_heatmap_id}_digits")]], selected = selected(), ht_list = ht_list()))
 			})
 		})
 
-		output[[qq("@{heatmap_id}_download_table")]] = downloadHandler(
+		output[[qq("@{non_prefix_heatmap_id}_download_table")]] = downloadHandler(
 			filename = function() {
 				qq("@{heatmap_id}_download_table.csv")
 			},
@@ -856,23 +860,22 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 			}
 		)
 
-		shiny_env$obs[[heatmap_id]][[qq("@{heatmap_id}_open_modal")]] = observeEvent(input[[qq("@{heatmap_id}_open_modal")]], {
-			
+		shiny_env$obs[[heatmap_id]][[qq("@{heatmap_id}_open_modal")]] = observeEvent(input[[qq("@{non_prefix_heatmap_id}_open_modal")]], {
 			req(heatmap_initialized())
-
-			InteractiveComplexHeatmapModal(input, output, session, sub_ht_list(), close_button = TRUE)
+		  
+			InteractiveComplexHeatmapModal(input, output, session, sub_ht_list(), heatmap_id = heatmap_id, close_button = TRUE)
 		})
 
 	} else if(only_brush_output_response) {
-		shiny_env$obs[[heatmap_id]][[qq("@{heatmap_id}_heatmap_brush")]] = observeEvent(input[[qq("@{heatmap_id}_heatmap_brush")]], {
+		shiny_env$obs[[heatmap_id]][[qq("@{heatmap_id}_heatmap_brush")]] = observeEvent(input[[qq("@{non_prefix_heatmap_id}_heatmap_brush")]], {
 
 			req(heatmap_initialized())
 			
-			if(is.null(input[[qq("@{heatmap_id}_heatmap_brush")]])) {
+			if(is.null(input[[qq("@{non_prefix_heatmap_id}_heatmap_brush")]])) {
 				selected( NULL )
 				selected_copy( selected() )
 			} else {
-				lt = get_pos_from_brush(input[[qq("@{heatmap_id}_heatmap_brush")]], res/72)
+				lt = get_pos_from_brush(input[[qq("@{non_prefix_heatmap_id}_heatmap_brush")]], res/72)
 			  	pos1 = lt[[1]]
 			  	pos2 = lt[[2]]
 			    
@@ -904,15 +907,15 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 
 	if(has_click_reponse) {
 		shiny_env$obs[[heatmap_id]][[qq("@{heatmap_id}_heatmap_click")]] = observeEvent(input[[ifelse(action %in% c("click", "hover"), 
-			                       qq("@{heatmap_id}_heatmap_mouse_action"), 
-			                       qq("@{heatmap_id}_heatmap_click"))]], {
+			                       qq("@{non_prefix_heatmap_id}_heatmap_mouse_action"), 
+			                       qq("@{non_prefix_heatmap_id}_heatmap_click"))]], {
 
 			req(heatmap_initialized())
 
 			if(action == "hover") {
-				pos1 = get_pos_from_click(input[[qq("@{heatmap_id}_heatmap_hover")]], res/72)
+				pos1 = get_pos_from_click(input[[qq("@{non_prefix_heatmap_id}_heatmap_hover")]], res/72)
 			} else {
-				pos1 = get_pos_from_click(input[[qq("@{heatmap_id}_heatmap_click")]], res/72)
+				pos1 = get_pos_from_click(input[[qq("@{non_prefix_heatmap_id}_heatmap_click")]], res/72)
 			}
 			  
 			if(is.null(pos1)) {
@@ -935,12 +938,12 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 				}
 			}
 
-			output[[qq("@{heatmap_id}_sub_heatmap")]] = renderPlot({
+			output[[qq("@{non_prefix_heatmap_id}_sub_heatmap")]] = renderPlot({
 				grid.newpage()
 				grid.text("No area on the heatmap is selected.", 0.5, 0.5, gp = gpar(fontsize = 14))
 			}, res = res)
 
-			output[[qq("@{heatmap_id}_sub_heatmap_control")]] = renderUI({
+			output[[qq("@{non_prefix_heatmap_id}_sub_heatmap_control")]] = renderUI({
 				NULL
 			})
 
@@ -1036,18 +1039,20 @@ getPositionFromDblclick = function(dblclick, ratio = 1) {
 make_sub_heatmap = function(input, output, session, heatmap_id, update_size = TRUE, 
 	selected = NULL, ht_list = NULL, ...) {
 	showNotification("Making the selected sub-heatmap.", duration = 2, type = "message")
-
+  
+  non_prefix_heatmap_id = remove_module_prefix(heatmap_id, session)
+  
 	shiny_env$is_in_sub_heatmap = TRUE
 	on.exit(shiny_env$is_in_sub_heatmap <- FALSE)
 
 	width = session$clientData[[qq("output_@{heatmap_id}_sub_heatmap_width")]]
     height = session$clientData[[qq("output_@{heatmap_id}_sub_heatmap_height")]]
 
-	show_row_names = input[[qq("@{heatmap_id}_show_row_names_checkbox")]]
-	show_column_names = input[[qq("@{heatmap_id}_show_column_names_checkbox")]]
-	show_annotation = input[[qq("@{heatmap_id}_show_annotation_checkbox")]]
-	show_cell_fun = input[[qq("@{heatmap_id}_show_cell_fun_checkbox")]]
-	fill_figure = input[[qq("@{heatmap_id}_fill_figure_checkbox")]]
+	show_row_names = input[[qq("@{non_prefix_heatmap_id}_show_row_names_checkbox")]]
+	show_column_names = input[[qq("@{non_prefix_heatmap_id}_show_column_names_checkbox")]]
+	show_annotation = input[[qq("@{non_prefix_heatmap_id}_show_annotation_checkbox")]]
+	show_cell_fun = input[[qq("@{non_prefix_heatmap_id}_show_cell_fun_checkbox")]]
+	fill_figure = input[[qq("@{non_prefix_heatmap_id}_fill_figure_checkbox")]]
 
 	if(is.null(show_row_names)) show_row_names = TRUE
 	if(is.null(show_column_names)) show_column_names = TRUE
@@ -1355,14 +1360,15 @@ make_sub_heatmap = function(input, output, session, heatmap_id, update_size = TR
 	}
 
 	if(update_size) {
-		updateNumericInput(session, qq("@{heatmap_id}_sub_heatmap_input_width"), value = session$clientData[[qq("output_@{heatmap_id}_sub_heatmap_width")]])
-		updateNumericInput(session, qq("@{heatmap_id}_sub_heatmap_input_height"), value = session$clientData[[qq("output_@{heatmap_id}_sub_heatmap_height")]])
+		updateNumericInput(session, qq("@{non_prefix_heatmap_id}_sub_heatmap_input_width"), value = session$clientData[[qq("output_@{heatmap_id}_sub_heatmap_width")]])
+		updateNumericInput(session, qq("@{non_prefix_heatmap_id}_sub_heatmap_input_height"), value = session$clientData[[qq("output_@{heatmap_id}_sub_heatmap_height")]])
 	}
 
 	return(ht_select)
 }
 
 # if annotation is included, top/bottom annotation are all put at the bottom of the matrix
+
 get_sub_matrix = function(heatmap_id, digits = 2, include_annotation = TRUE, selected = NULL, ht_list = NULL) {
 
 	dev.null()
@@ -1627,8 +1633,10 @@ collect_data_frame_from_anno = function(ha, digits, direction) {
 default_brush_action = function(input, output, session, heatmap_id,
 	default_text = "Selected area should overlap to heatmap bodies.",
 	selected = NULL, ht_list = NULL) {
+  
+  non_prefix_heatmap_id = remove_module_prefix(heatmap_id, session)
 
-	output[[qq("@{heatmap_id}_info")]] = renderUI({
+	output[[qq("@{non_prefix_heatmap_id}_info")]] = renderUI({
 
 		if(is.null(selected)) {
 			HTML(qq("<p>@{default_text}</p>"))
@@ -1697,7 +1705,9 @@ default_brush_action = function(input, output, session, heatmap_id,
 }
 
 default_click_action = function(input, output, session, heatmap_id, selected = NULL, ht_list = NULL, action = "click") {
-	output[[qq("@{heatmap_id}_info")]] = renderUI({
+  non_prefix_heatmap_id = remove_module_prefix(heatmap_id, session)
+
+	output[[qq("@{non_prefix_heatmap_id}_info")]] = renderUI({
 
 	    if(is.null(selected)) {
 	    	HTML("<p>No cell is selected.</p>")

--- a/R/shiny-server.R
+++ b/R/shiny-server.R
@@ -43,7 +43,7 @@ makeInteractiveComplexHeatmap = function(input, output, session, ht_list,
 	dblclick_action = NULL, brush_action = NULL, res = 72,
 	show_cell_fun = TRUE, show_layer_fun = TRUE) {
 
-	heatmap_id = validate_heatmap_id(heatmap_id)
+	assert_starts_with_digits(heatmap_id)
 
 	if(is.null(shiny_env$heatmap[[heatmap_id]])) {
 		stop_wrap(qq("Cannot find heatmap '@{heatmap_id}'. Make sure 'ui' is generated in the same session as 'server'. If 'ui' is generated in a package, please generate it dynamically by wrapping into a function, while not do it statically."))

--- a/R/shiny-ui.R
+++ b/R/shiny-ui.R
@@ -350,7 +350,7 @@ originalHeatmapOutput = function(heatmap_id, title = NULL,
 		stylesheet = "jquery-ui.min.css"
     )
 
-    pickr_dep = htmltools::htmlDependency(
+  pickr_dep = htmltools::htmlDependency(
 		name       = "pickr",
 		version    = "1.8.0",
 		package    = "InteractiveComplexHeatmap",
@@ -367,7 +367,7 @@ originalHeatmapOutput = function(heatmap_id, title = NULL,
 		stylesheet = c("all.min.css", "v4-shims.min.css")
     )
 
-    clipboard_dep = htmltools::htmlDependency(
+  clipboard_dep = htmltools::htmlDependency(
 		name       = "clipboard",
 		version    = "2.0.7",
 		package    = "InteractiveComplexHeatmap",
@@ -375,7 +375,7 @@ originalHeatmapOutput = function(heatmap_id, title = NULL,
 		script     = c("clipboard.min.js")
     )
 
-    mousestop_dep = htmltools::htmlDependency(
+  mousestop_dep = htmltools::htmlDependency(
 		name       = "mousestop",
 		version    = "3.0.1",
 		package    = "InteractiveComplexHeatmap",
@@ -399,7 +399,7 @@ originalHeatmapOutput = function(heatmap_id, title = NULL,
     	pickr_opacity = brush_opt$opacity
     }
 
-    if(identical(containment, FALSE)) {
+  if(identical(containment, FALSE)) {
 		containment = "false"
 	} else if(identical(containment, TRUE)) {
 		containment = qq("$('#@{heatmap_id}_heatmap_group').parent()")

--- a/R/shiny-ui.R
+++ b/R/shiny-ui.R
@@ -62,7 +62,7 @@ InteractiveComplexHeatmapOutput = function(heatmap_id = NULL,
 		heatmap_id = paste0("ht", get_widget_index())
 	}
 
-	heatmap_id = validate_heatmap_id(heatmap_id)
+	assert_starts_with_digits(heatmap_id)
 
 	if(layout %in% c("12|3")) {
 		layout = "(1-2)|3"
@@ -273,7 +273,7 @@ originalHeatmapOutput = function(heatmap_id, title = NULL,
 		}
 	}
 
-	heatmap_id = validate_heatmap_id(heatmap_id)
+	assert_starts_with_digits(heatmap_id)
 
 	if(is.null(shiny_env$heatmap[[heatmap_id]])) {
 		shiny_env$heatmap[[heatmap_id]] = list()
@@ -541,7 +541,7 @@ subHeatmapOutput = function(heatmap_id, title = NULL,
 		}
 	}
 
-	heatmap_id = validate_heatmap_id(heatmap_id)
+	assert_starts_with_digits(heatmap_id)
 
 	if(is.null(shiny_env$heatmap[[heatmap_id]])) {
 		shiny_env$heatmap[[heatmap_id]] = list()
@@ -692,7 +692,7 @@ HeatmapInfoOutput = function(heatmap_id, title = NULL, width = 400,
 		}
 	}
 
-	heatmap_id = validate_heatmap_id(heatmap_id)
+	assert_starts_with_digits(heatmap_id)
 
 	if(is.null(shiny_env$heatmap[[heatmap_id]])) {
 		shiny_env$heatmap[[heatmap_id]] = list()

--- a/R/shiny-ui.R
+++ b/R/shiny-ui.R
@@ -417,8 +417,7 @@ originalHeatmapOutput = function(heatmap_id, title = NULL,
     		 pickr_dep, 
     		 clipboard_dep, 
     		 fontawesome_dep, 
-    		 mousestop_dep,
-    		 add_js_css_dep(heatmap_id, js_file = "ht-main.js", css_file = "ht-main.css")
+    		 mousestop_dep
     	),
 
     	# htmlOutput(qq("@{heatmap_id}_warning")),
@@ -443,7 +442,8 @@ originalHeatmapOutput = function(heatmap_id, title = NULL,
 			{
 				tbl = list(
 					tabPanel(HTML("<i class='fa fa-search'></i>"),
-						div(id = qq('@{heatmap_id}_tabs-search'), 
+						div(id = qq('@{heatmap_id}_tabs-search'),
+					    add_js_css_dep(heatmap_id, js_file = "ht-main.js", css_file = "ht-main.css"),
 							div(textInput(qq("@{heatmap_id}_keyword"), placeholder = "Multiple keywords separated by ','", label = "Keywords"), style = "width:250px;float:left;"),
 							div(checkboxInput(qq("@{heatmap_id}_search_regexpr"), label = "Regular expression", value = FALSE), style = "width:150px;float:left;padding-top:20px;padding-left:4px;"),
 							div(style = "clear: both;"),
@@ -768,7 +768,7 @@ add_js_css_dep = function(heatmap_id, js_file, css_file, envir = parent.frame())
     	version = packageVersion("InteractiveComplexHeatmap")
     }
     temp_js = qq(ht_js, envir = envir)
-    temp_js = paste0("<script>\n", temp_js, "\n</script>\n")
+
 
     if(identical(topenv(), .GlobalEnv)) {
     	ht_css = paste(readLines(qq("~/project/development/InteractiveComplexHeatmap/inst/template/@{css_file}")), collapse = "\n")
@@ -776,14 +776,9 @@ add_js_css_dep = function(heatmap_id, js_file, css_file, envir = parent.frame())
 		ht_css = paste(readLines(system.file("template", css_file, package = "InteractiveComplexHeatmap")), collapse = "\n")
     }
     temp_css = qq(ht_css, envir = envir)
-    temp_css = paste0("<style>\n", temp_css, "\n</style>")
-
-    htmltools::htmlDependency(
-		name   = qq("interactive-complex-heatmap-@{heatmap_id}-@{gsub('.(js|css)$', '', basename(js_file))}"),
-		version = version,
-		package    = "InteractiveComplexHeatmap",
-		src        = "www",
-		script     = "foo.js",
-		head = paste0(temp_js, "\n", temp_css)
+    
+    tagList(
+      tags$script(HTML(temp_js)),
+      tags$style(HTML(temp_css))
     )
 }

--- a/R/shiny-widget.R
+++ b/R/shiny-widget.R
@@ -81,8 +81,14 @@ InteractiveComplexHeatmapModal = function(
 	
 	if(is.null(heatmap_id)) {
 		increase_widget_index()
-		heatmap_id = paste0("ht", get_widget_index())
+		heatmap_id = session$ns(paste0("ht", get_widget_index()))
+	} else {
+	  increase_widget_index()
+	  heatmap_id = paste0(heatmap_id, get_widget_index())
 	}
+  
+  non_prefix_heatmap_id = remove_module_prefix(heatmap_id, session)
+  
 
 	assert_starts_with_digits(heatmap_id)
 
@@ -95,7 +101,7 @@ InteractiveComplexHeatmapModal = function(
 
 	cancel_action = match.arg(cancel_action)[1]
 
-	output[[qq("@{heatmap_id}_heatmap_modal_ui")]] = renderUI({
+	output[[qq("@{non_prefix_heatmap_id}_heatmap_modal_ui")]] = renderUI({
 		div(id = qq("@{heatmap_id}_heatmap_modal_background"),
 			div(id = qq("@{heatmap_id}_heatmap_modal"),
 				class = "heatmap_modal",
@@ -155,6 +161,7 @@ InteractiveComplexHeatmapModal = function(
 			if(close_button) {
 				tags$script(HTML(qq("
 					$('#@{heatmap_id}_heatmap_modal_close').click(function() {
+
 				        if('@{cancel_action}' == 'remove') {
 				        	Shiny.setInputValue('@{heatmap_id}_heatmap_modal_remove', Math.random());
 				        	$('#@{heatmap_id}_heatmap_modal_ui').remove();
@@ -183,6 +190,7 @@ InteractiveComplexHeatmapModal = function(
 			},
 			tags$script(HTML(qq("
 				$('#@{heatmap_id}_heatmap_modal_close_icon').click(function() {
+
 			        if('@{cancel_action}' == 'remove') {
 			        	Shiny.setInputValue('@{heatmap_id}_heatmap_modal_remove', Math.random());
 			        	$('#@{heatmap_id}_heatmap_modal_ui').remove();
@@ -217,12 +225,12 @@ InteractiveComplexHeatmapModal = function(
 		)
 	})
 
-	observeEvent(input[[qq("@{heatmap_id}_heatmap_modal_open")]], {
+	observeEvent(input[[qq("@{non_prefix_heatmap_id}_heatmap_modal_open")]], {
 		makeInteractiveComplexHeatmap(input, output, session, ht_list, heatmap_id = heatmap_id,
 			click_action = click_action, brush_action = brush_action)
 	}, once = TRUE)
 
-	observeEvent(input[[qq("@{heatmap_id}_heatmap_modal_remove")]], {
+	observeEvent(input[[qq("@{non_prefix_heatmap_id}_heatmap_modal_remove")]], {
 		removeUI(qq("#@{heatmap_id}_heatmap_modal_background"))
 	})
 }

--- a/R/shiny-widget.R
+++ b/R/shiny-widget.R
@@ -195,20 +195,20 @@ InteractiveComplexHeatmapModal = function(
 				// when parent element has 'position:fixed', the color picker is not correctly positioned
 				// following code manually adjust the positions of the color picker
 				$($('#@{heatmap_id}_heatmap_control ul li')[1]).click(function() {
-					var @{heatmap_id}_color_picker_buttons = $('#@{heatmap_id}_tabs-brush button.pcr-button');
+					var color_picker_buttons = $('#@{heatmap_id}_tabs-brush button.pcr-button');
 						
-					$(@{heatmap_id}_color_picker_buttons[0]).click(function() {
-						var offset = $(@{heatmap_id}_color_picker_buttons[0]).offset();
-						var w = $(@{heatmap_id}_color_picker_buttons[0]).outerWidth();
-						var h = $(@{heatmap_id}_color_picker_buttons[0]).outerHeight();
+					$(color_picker_buttons[0]).click(function() {
+						var offset = $(color_picker_buttons[0]).offset();
+						var w = $(color_picker_buttons[0]).outerWidth();
+						var h = $(color_picker_buttons[0]).outerHeight();
 						$('#@{heatmap_id}_tabs-brush .pcr-app.visible').css('top', offset.top + h + 5).
 						                                                css('left', offset.left);
 					})
 
-					$(@{heatmap_id}_color_picker_buttons[1]).click(function() {
-						var offset = $(@{heatmap_id}_color_picker_buttons[1]).offset();
-						var w = $(@{heatmap_id}_color_picker_buttons[1]).outerWidth();
-						var h = $(@{heatmap_id}_color_picker_buttons[1]).outerHeight();
+					$(color_picker_buttons[1]).click(function() {
+						var offset = $(color_picker_buttons[1]).offset();
+						var w = $(color_picker_buttons[1]).outerWidth();
+						var h = $(color_picker_buttons[1]).outerHeight();
 						$('#@{heatmap_id}_tabs-brush .pcr-app.visible').css('top', offset.top + h + 5).
 						                                                css('left', offset.left);
 					})

--- a/R/shiny-widget.R
+++ b/R/shiny-widget.R
@@ -84,7 +84,7 @@ InteractiveComplexHeatmapModal = function(
 		heatmap_id = paste0("ht", get_widget_index())
 	}
 
-	heatmap_id = validate_heatmap_id(heatmap_id)
+	assert_starts_with_digits(heatmap_id)
 
 	insertUI(selector = qq("body"), 
 		where = "beforeEnd",
@@ -314,7 +314,7 @@ InteractiveComplexHeatmapWidget = function(
 		heatmap_id = paste0("ht", get_widget_index())
 	}
 
-	heatmap_id = validate_heatmap_id(heatmap_id)
+	assert_starts_with_digits(heatmap_id)
 
 	if(is.function(js_code)) js_code = js_code(heatmap_id)
 	js_code = paste(js_code, collapse = "\n")

--- a/R/utils.R
+++ b/R/utils.R
@@ -183,3 +183,20 @@ validate_heatmap_id = function(id) {
 		id
 	}
 }
+
+remove_module_prefix = function(heatmap_id, session) {
+  prefix = session$ns("")
+
+  if(nchar(prefix) == 0) {
+    heatmap_id
+  } else {
+    substring(heatmap_id, nchar(session$ns("")) + 1)
+  }
+}
+
+assert_starts_with_digits = function(heatmap_id) {
+  if(grepl("^\\d", heatmap_id)) {
+    stop_wrap("heatmap_id cannot start with digits.")
+  }
+}
+


### PR DESCRIPTION
Hello, first of all thank you for such a great work creating ComplexHeatmap and InteractiveComplexHeatmap packages. They are really great tools. My heart was broken once I found out InteractiveComplexHeatmap doesn't work with shiny modules. That's a big loss for shiny community because the modules are the foundation for any shiny app that is bigger than some plot demo. I've accepted the challenge of fixing it and here is what I found out.

It's not a secret that shiny works with some ids to bind ui and server. If you work directly in shiny's ui and server element's id equals it's id in html. Things are clear and easy so far. Once we introduce modules namspaces come into play. If we take a look into ui side of simple app with numeric input and text output that displays the number from the input It'd look like this:
```
moduleTestUI <- function(id) {
  ns <- NS(id)
  tagList(
    numericInput(ns("number_in"), "test", 1),
    textOutput(ns("text_out"))
  )
}

ui <- fluidPage(
  moduleTestUI("module_prefix")
)
```
What changed is that now we wrap every shiny id within module with `ns()` function that basically takes the given module prefix (in our case `module_prefix`) and prepends it to given id making sure the elements have the unique id. In our case that would be: `module_prefix-number_in` and `module_prefix-text_out`. If we would nest some modules the prefixes from each module will carry on with each step e.g. `module1-module2-module_prefix-number_in` etc.

If we now take a look into server side:
```
moduleTestServer <- function(id) {
  moduleServer(id, function(input, output, session) {
      output$text_out <- renderText({
        input$number_in
      })
    }
  )
}
server <- function(input, output, session) {
  moduleTestServer("module_prefix")
}
```
We create module server with the same module prefix but inside module server function we don't have to deal with namespace at all. We directly refer to input and output elements via its non-prefixed id e.g. `input$number_in`. It's beacause Shiny does some shiny magic to make modules transparent to each other and allow you to not care about namespace at all. It'll behave like that no matter how many modules we nest.

That was the issue I identified that prevented InteractiveComplexHeatmap from working with shiny modules. Package referred to inputs and outputs via it's full id which works only when things are not module prefixed. I've noticed 2 cases where you have to replace whole html id with non-prefixed heatmap id:
- Whenever you access `input` and `output` objects
- Whenever you use functions like `updateNumericInput` and similiar where you provide `session` element as parameter

To get this non-prefixed heatmap id I've added this helper:
```
remove_module_prefix = function(heatmap_id, session) {
  prefix = session$ns("")

  if(nchar(prefix) == 0) {
    heatmap_id
  } else {
    substring(heatmap_id, nchar(session$ns("")) + 1)
  }
}
```
It leverages the fact that if we supply empty string to `ns()` function we will know what the prefix is and with that we can easily subtract it from our full id.


To make this code to work I've had to revert your changes with heatmap_id validation. I've seen the [issue 105](https://github.com/jokergoo/InteractiveComplexHeatmap/issues/105). The default concatenation character for shiny modules is `-`. I know you can change it but it's quite widely used and changing that especially in some bigger apps can be quite challengeing. I think the line that causes you trouble with dash character is [this one](https://github.com/jokergoo/InteractiveComplexHeatmap/blob/master/R/shiny-widget.R#L198). There's no need for making this variable name prefixed because it's only avaliable in its bracket scope. I fixed that in this PR too. 

I've replaced the validation function with assertion so you can throw errors when heatmap_id is not valid i.e. starts with digits. I'd strongly suggest to not modify the ids directly because it creates confusion and makes thing harder to debug. We should make users life easier but there's a line ;)


Last but not least I've changed the way js and css templates are loaded. I've run into really strange issue on my windows machine where the javascript is loaded before the html. That caused Pickr.js to load before required div (`'@{heatmap_id}_tabs-search'`) was loaded. I've moved it right into that div to make sure its loading in the same time (I've seen you had same approach for the other outputs).

Here's also an example app that I used to battle test my changes:
```
library(shiny)

m = matrix(rnorm(100), 10)
ht = Heatmap(m)

moduleTestUI <- function(id) {
  ns <- NS(id)
  tagList(
    InteractiveComplexHeatmapOutput(ns("ht_id"))
  )
}

moduleTestServer <- function(id) {
  moduleServer(id, function(input, output, session) {
      makeInteractiveComplexHeatmap(input, output, session, ht, session$ns("ht_id"))
    }
  )
}


ui = fluidPage(
  moduleTestUI("mod_prefix")
)

server = function(input, output, session) {
  moduleTestServer("mod_prefix")
}

shiny::shinyApp(ui, server)
```
